### PR TITLE
added a filter for logger for it not to be shown in prod enviroment

### DIFF
--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -5,7 +5,12 @@ import rootReducer from './root-reducer';
 
 import {persistStore} from 'redux-persist';
 
-const middlewares = [logger];
+const middlewares = [];
+
+if(process.env.NODE_ENV == 'development'){
+    middlewares.push(logger);
+}
+
 
 export const store = createStore(rootReducer, applyMiddleware(...middlewares));
 


### PR DESCRIPTION
Logger middleware won't trigger on production anymore.